### PR TITLE
added new output type: script-address

### DIFF
--- a/prefix.c
+++ b/prefix.c
@@ -184,6 +184,11 @@ BitcoinKeyPrefix BitcoinNetworkType_GetPrivateKeyPrefix(const struct BitcoinNetw
 	return n->private_key_prefix;
 }
 
+BitcoinKeyPrefix BitcoinNetworkType_GetScriptPrefix(const struct BitcoinNetworkType *n)
+{
+	return n->script_prefix;
+}
+
 const struct BitcoinNetworkType *Bitcoin_GetNetworkTypeByName(const char *name)
 {
 	const struct BitcoinNetworkType *pn = network_types;

--- a/prefix.h
+++ b/prefix.h
@@ -19,6 +19,7 @@ const struct BitcoinNetworkType *Bitcoin_GetNetworkTypeByPrivateKeyPrefix(const 
 
 BitcoinKeyPrefix BitcoinNetworkType_GetPublicKeyPrefix(const struct BitcoinNetworkType *n);
 BitcoinKeyPrefix BitcoinNetworkType_GetPrivateKeyPrefix(const struct BitcoinNetworkType *n);
+BitcoinKeyPrefix BitcoinNetworkType_GetScriptPrefix(const struct BitcoinNetworkType *n);
 
 void Bitcoin_ListNetworks(FILE *output);
 


### PR DESCRIPTION
I needed to add  `--output-type script-address` for a coin project. So here's my patch for the upstream project.

Usage example:

`./bitcoin-tool --network bitcoin --input-type private-key-wif --input-format base58check --input 5JZjfs5wJv1gNkJXCmYpyj6VxciqPkwmK4yHW8zMmPN1PW7Hk7F --output-type script-address --output-format base58check`