### PR TITLE
add macOS specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Requires Cygwin packages: `bash`, `make`, `mingw64-x86_64-gcc-core`, `openssl-de
 
 Use `make CC=other_cc` to specify a different compiler if needed.
 
+### macOS
+Export flags for openssl lib paths before running `make`.
+
+```bash
+export LDFLAGS="-L/usr/local/opt/openssl/lib -L/usr/local/lib -L/usr/local/opt/expat/lib"
+export CFLAGS="-I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include"
+export CPPFLAGS="-I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include"
+```
+
 ## Description
 I created this because I couldn't find an offline tool or library able
 to create addresses from Bitcoin private keys, and as a learning exercise in


### PR DESCRIPTION
I was running into an openssl lib path issue when installing on macOS:

```
$ make
cc -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long    -c -o main.o main.c
main.c:11:10: fatal error: 'openssl/err.h' file not found
#include <openssl/err.h>
         ^~~~~~~~~~~~~~~
1 error generated.
make: *** [main.o] Error 1
```

then stumbled across [this answer](https://github.com/processone/ejabberd/issues/1107#issuecomment-217828211) that mentions you have to export flags for specifying openssl lib paths:

```
export LDFLAGS="-L/usr/local/opt/openssl/lib -L/usr/local/lib -L/usr/local/opt/expat/lib"
export CFLAGS="-I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include"
export CPPFLAGS="-I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include"
```

and now `make` works:

```
$ make
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o main.o main.c
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o keys.o keys.c
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o hash.o hash.c
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o base58.o base58.c
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o result.o result.c
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o combination.o combination.c
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o applog.o applog.c
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o utility.o utility.c
cc -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include -D OS_UNIX -ansi -Wall  -O2 -Wno-long-long  -I/usr/local/opt/openssl/include/ -I/usr/local/include -I/usr/local/opt/expat/include  -c -o prefix.o prefix.c
cc -o bitcoin-tool main.o keys.o hash.o base58.o result.o combination.o applog.o utility.o prefix.o -L /usr/lib -lcrypto -lssl
```