### PR TITLE
bech32 address format added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 CFLAGS += -ansi -Wall $(CFLAGS_DEBUG) $(CFLAGS_OPTIMISE) \
 	$(CFLAGS_DISABLE_WARNINGS) $(INCLUDE)
 
-OBJECTS = main.o keys.o hash.o base58.o result.o combination.o applog.o \
+OBJECTS = main.o keys.o hash.o base58.o segwit_addr.o result.o combination.o applog.o \
 	utility.o prefix.o
 
 .PHONY : all clean test

--- a/prefix.c
+++ b/prefix.c
@@ -11,12 +11,14 @@ Peercoin, Primecoin and Zetacoin use the same constants.
 */
 	{
 		.name                    = "bitcoin",
+		.hrp                     = "bc",
 		.public_key_prefix       = 0,
 		.script_prefix           = 5,
 		.private_key_prefix      = 128
 	},
 	{
 		.name                    = "bitcoin-testnet",
+		.hrp                     = "tb",
 		.public_key_prefix       = 111,
 		.script_prefix           = 196,
 		.private_key_prefix      = 239
@@ -30,12 +32,14 @@ https://github.com/litecoin-project/litecoin/blob/88e2a2e8988b89f905145bdc9af8c3
 */
 	{
 		.name                    = "litecoin",
+		.hrp                     = "ltc",
 		.public_key_prefix       = 48,
 		.script_prefix           = 5,
 		.private_key_prefix      = 48+128
 	},
 	{
 		.name                    = "litecoin-testnet",
+		.hrp                     = "tltc",
 		.public_key_prefix       = 111,
 		.script_prefix           = 196,
 		.private_key_prefix      = 111+128
@@ -49,12 +53,14 @@ https://github.com/FeatherCoin/Feathercoin-0.8.5/blob/master-0.8/src/base58.h#L4
 */
 	{
 		.name                    = "feathercoin",
+		.hrp                     = "fc",
 		.public_key_prefix       = 14,
 		.script_prefix           = 5,
 		.private_key_prefix      = 14+128
 	},
 	{
 		.name                    = "feathercoin-testnet",
+		.hrp                     = "tfc",
 		.public_key_prefix       = 111,
 		.script_prefix           = 196,
 		.private_key_prefix      = 111+128
@@ -68,12 +74,14 @@ https://github.com/dogecoin/dogecoin/blob/v1.5.0/src/base58.h#L404
 */
 	{
 		.name                    = "dogecoin",
+		.hrp                     = "dc",
 		.public_key_prefix       = 30,
 		.script_prefix           = 22,
 		.private_key_prefix      = 30+128
 	},
 	{
 		.name                    = "dogecoin-testnet",
+		.hrp                     = "tdc",
 		.public_key_prefix       = 113,
 		.script_prefix           = 196,
 		.private_key_prefix      = 113+128
@@ -87,12 +95,14 @@ https://github.com/MaxGuevara/quark/blob/v0.8.3.20/src/base58.h#L403
 */
 	{
 		.name                    = "quarkcoin",
+		.hrp                     = "qc",
 		.public_key_prefix       = 58,
 		.script_prefix           = 9,
 		.private_key_prefix      = 58+128
 	},
 	{
 		.name                    = "quarkcoin-testnet",
+		.hrp                     = "tqc",
 		.public_key_prefix       = 119,
 		.script_prefix           = 199,
 		.private_key_prefix      = 119+128
@@ -106,12 +116,14 @@ https://github.com/darkcoinproject/darkcoin/blob/master/src/base58.h#L403
 */
 	{
 		.name                    = "darkcoin",
+		.hrp                     = "xc",
 		.public_key_prefix       = 76,
 		.script_prefix           = 9,
 		.private_key_prefix      = 76+128
 	},
 	{
 		.name                    = "darkcoin-testnet",
+		.hrp                     = "txc",
 		.public_key_prefix       = 111,
 		.script_prefix           = 196,
 		.private_key_prefix      = 111+128
@@ -125,12 +137,14 @@ https://github.com/jyap808/coinmarketscoin/blob/master/src/base58.h#L425
 */
 	{
 		.name                    = "jumbucks",
+		.hrp                     = "jb",
 		.public_key_prefix       = 43,
 		.script_prefix           = 105,
 		.private_key_prefix      = 43+128
 	},
 	{
 		.name                    = "jumbucks-testnet",
+		.hrp                     = "tjb",
 		.public_key_prefix       = 107,
 		.script_prefix           = 176,
 		.private_key_prefix      = 107+128
@@ -144,12 +158,14 @@ https://github.com/ppcoin/ppcoin/blob/v0.5.2ppc/src/base58.h#L428
 */
 	{
 		.name                    = "peercoin",
+		.hrp                     = "pc",
 		.public_key_prefix       = 55,
 		.script_prefix           = 117,
 		.private_key_prefix      = 55+128
 	},
 	{
 		.name                    = "peercoin-testnet",
+		.hrp                     = "tpc",
 		.public_key_prefix       = 111,
 		.script_prefix           = 196,
 		.private_key_prefix      = 111+128
@@ -162,12 +178,14 @@ https://github.com/namecoin/namecoin-core/blob/09bdf373fb3cefa9faf868f1c415e0498
 */
 	{
 		.name                    = "namecoin",
+		.hrp                     = "nc",
 		.public_key_prefix       = 52,
 		.script_prefix           = 13,
 		.private_key_prefix      = 52+128
 	},
 	{
 		.name                    = "namecoin-testnet",
+		.hrp                     = "tn",
 		.public_key_prefix       = 111,
 		.script_prefix           = 196,
 		.private_key_prefix      = 111+128
@@ -179,6 +197,7 @@ https://github.com/jl777/komodo/blob/a86845f3dc5444d24f4420908125f4c4cb58b4ff/sr
 */
 	{
 		.name                    = "komodo",
+		.hrp                     = "zs",
 		.public_key_prefix       = 60,
 		.script_prefix           = 85,
 		.private_key_prefix      = 60+128
@@ -201,6 +220,20 @@ const struct BitcoinNetworkType *Bitcoin_GetNetworkTypeByName(const char *name)
 
 	while (pn != network_types + (sizeof(network_types)/sizeof(network_types[0]))) {
 		if (strcmp(name, pn->name) == 0) {
+			return pn;
+		}
+		pn++;
+	}
+
+	return NULL;
+}
+
+const struct BitcoinNetworkType *Bitcoin_GetNetworkTypeByHrp(const char *hrp)
+{
+	const struct BitcoinNetworkType *pn = network_types;
+
+	while (pn != network_types + (sizeof(network_types)/sizeof(network_types[0]))) {
+		if (strcmp(hrp, pn->hrp) == 0) {
 			return pn;
 		}
 		pn++;

--- a/prefix.h
+++ b/prefix.h
@@ -9,12 +9,14 @@ typedef unsigned BitcoinKeyPrefix;
 struct BitcoinNetworkType
 {
 	const char *name;
+	const char *hrp;
 	BitcoinKeyPrefix public_key_prefix,
 		script_prefix,
 		private_key_prefix;
 };
 
 const struct BitcoinNetworkType *Bitcoin_GetNetworkTypeByName(const char *name);
+const struct BitcoinNetworkType *Bitcoin_GetNetworkTypeByHrp(const char *hrp);
 const struct BitcoinNetworkType *Bitcoin_GetNetworkTypeByPrivateKeyPrefix(const BitcoinKeyPrefix prefix);
 
 BitcoinKeyPrefix BitcoinNetworkType_GetPublicKeyPrefix(const struct BitcoinNetworkType *n);

--- a/segwit_addr.c
+++ b/segwit_addr.c
@@ -1,0 +1,191 @@
+/* Copyright (c) 2017 Pieter Wuille
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "segwit_addr.h"
+
+uint32_t bech32_polymod_step(uint32_t pre) {
+    uint8_t b = pre >> 25;
+    return ((pre & 0x1FFFFFF) << 5) ^
+        (-((b >> 0) & 1) & 0x3b6a57b2UL) ^
+        (-((b >> 1) & 1) & 0x26508e6dUL) ^
+        (-((b >> 2) & 1) & 0x1ea119faUL) ^
+        (-((b >> 3) & 1) & 0x3d4233ddUL) ^
+        (-((b >> 4) & 1) & 0x2a1462b3UL);
+}
+
+static const char* charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+static const int8_t charset_rev[128] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+};
+
+int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t data_len) {
+    uint32_t chk = 1;
+    size_t i = 0;
+    while (hrp[i] != 0) {
+        int ch = hrp[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+
+        if (ch >= 'A' && ch <= 'Z') return 0;
+        chk = bech32_polymod_step(chk) ^ (ch >> 5);
+        ++i;
+    }
+    if (i + 7 + data_len > 90) return 0;
+    chk = bech32_polymod_step(chk);
+    while (*hrp != 0) {
+        chk = bech32_polymod_step(chk) ^ (*hrp & 0x1f);
+        *(output++) = *(hrp++);
+    }
+    *(output++) = '1';
+    for (i = 0; i < data_len; ++i) {
+        if (*data >> 5) return 0;
+        chk = bech32_polymod_step(chk) ^ (*data);
+        *(output++) = charset[*(data++)];
+    }
+    for (i = 0; i < 6; ++i) {
+        chk = bech32_polymod_step(chk);
+    }
+    chk ^= 1;
+    for (i = 0; i < 6; ++i) {
+        *(output++) = charset[(chk >> ((5 - i) * 5)) & 0x1f];
+    }
+    *output = 0;
+    return 1;
+}
+
+int bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input) {
+    uint32_t chk = 1;
+    size_t i;
+    size_t input_len = strlen(input);
+    size_t hrp_len;
+    int have_lower = 0, have_upper = 0;
+    if (input_len < 8 || input_len > 90) {
+        return 0;
+    }
+    *data_len = 0;
+    while (*data_len < input_len && input[(input_len - 1) - *data_len] != '1') {
+        ++(*data_len);
+    }
+    hrp_len = input_len - (1 + *data_len);
+    if (1 + *data_len >= input_len || *data_len < 6) {
+        return 0;
+    }
+    *(data_len) -= 6;
+    for (i = 0; i < hrp_len; ++i) {
+        int ch = input[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+        if (ch >= 'a' && ch <= 'z') {
+            have_lower = 1;
+        } else if (ch >= 'A' && ch <= 'Z') {
+            have_upper = 1;
+            ch = (ch - 'A') + 'a';
+        }
+        hrp[i] = ch;
+        chk = bech32_polymod_step(chk) ^ (ch >> 5);
+    }
+    hrp[i] = 0;
+    chk = bech32_polymod_step(chk);
+    for (i = 0; i < hrp_len; ++i) {
+        chk = bech32_polymod_step(chk) ^ (input[i] & 0x1f);
+    }
+    ++i;
+    while (i < input_len) {
+        int v = (input[i] & 0x80) ? -1 : charset_rev[(int)input[i]];
+        if (input[i] >= 'a' && input[i] <= 'z') have_lower = 1;
+        if (input[i] >= 'A' && input[i] <= 'Z') have_upper = 1;
+        if (v == -1) {
+            return 0;
+        }
+        chk = bech32_polymod_step(chk) ^ v;
+        if (i + 6 < input_len) {
+            data[i - (1 + hrp_len)] = v;
+        }
+        ++i;
+    }
+    if (have_lower && have_upper) {
+        return 0;
+    }
+    return chk == 1;
+}
+
+static int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad) {
+    uint32_t val = 0;
+    int bits = 0;
+    uint32_t maxv = (((uint32_t)1) << outbits) - 1;
+    while (inlen--) {
+        val = (val << inbits) | *(in++);
+        bits += inbits;
+        while (bits >= outbits) {
+            bits -= outbits;
+            out[(*outlen)++] = (val >> bits) & maxv;
+        }
+    }
+    if (pad) {
+        if (bits) {
+            out[(*outlen)++] = (val << (outbits - bits)) & maxv;
+        }
+    } else if (((val << (outbits - bits)) & maxv) || bits >= inbits) {
+        return 0;
+    }
+    return 1;
+}
+
+int segwit_addr_encode(char *output, const char *hrp, int witver, const uint8_t *witprog, size_t witprog_len) {
+    uint8_t data[65];
+    size_t datalen = 0;
+    if (witver > 16) return 0;
+    if (witver == 0 && witprog_len != 20 && witprog_len != 32) return 0;
+    if (witprog_len < 2 || witprog_len > 40) return 0;
+    data[0] = witver;
+    convert_bits(data + 1, &datalen, 5, witprog, witprog_len, 8, 1);
+    ++datalen;
+    return bech32_encode(output, hrp, data, datalen);
+}
+
+int segwit_addr_decode(int* witver, uint8_t* witdata, size_t* witdata_len, const char* hrp, const char* addr) {
+    uint8_t data[84];
+    char hrp_actual[84];
+    size_t data_len;
+    if (!bech32_decode(hrp_actual, data, &data_len, addr)) return 0;
+    if (data_len == 0 || data_len > 65) return 0;
+    if (strncmp(hrp, hrp_actual, 84) != 0) return 0;
+    if (data[0] > 16) return 0;
+    *witdata_len = 0;
+    if (!convert_bits(witdata, witdata_len, 8, data + 1, data_len - 1, 5, 0)) return 0;
+    if (*witdata_len < 2 || *witdata_len > 40) return 0;
+    if (data[0] == 0 && *witdata_len != 20 && *witdata_len != 32) return 0;
+    *witver = data[0];
+    return 1;
+}

--- a/segwit_addr.h
+++ b/segwit_addr.h
@@ -1,0 +1,101 @@
+/* Copyright (c) 2017 Pieter Wuille
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _SEGWIT_ADDR_H_
+#define _SEGWIT_ADDR_H_ 1
+
+#include <stdint.h>
+
+/** Encode a SegWit address
+ *
+ *  Out: output:   Pointer to a buffer of size 73 + strlen(hrp) that will be
+ *                 updated to contain the null-terminated address.
+ *  In:  hrp:      Pointer to the null-terminated human readable part to use
+ *                 (chain/network specific).
+ *       ver:      Version of the witness program (between 0 and 16 inclusive).
+ *       prog:     Data bytes for the witness program (between 2 and 40 bytes).
+ *       prog_len: Number of data bytes in prog.
+ *  Returns 1 if successful.
+ */
+int segwit_addr_encode(
+    char *output,
+    const char *hrp,
+    int ver,
+    const uint8_t *prog,
+    size_t prog_len
+);
+
+/** Decode a SegWit address
+ *
+ *  Out: ver:      Pointer to an int that will be updated to contain the witness
+ *                 program version (between 0 and 16 inclusive).
+ *       prog:     Pointer to a buffer of size 40 that will be updated to
+ *                 contain the witness program bytes.
+ *       prog_len: Pointer to a size_t that will be updated to contain the length
+ *                 of bytes in prog.
+ *       hrp:      Pointer to the null-terminated human readable part that is
+ *                 expected (chain/network specific).
+ *       addr:     Pointer to the null-terminated address.
+ *  Returns 1 if successful.
+ */
+int segwit_addr_decode(
+    int* ver,
+    uint8_t* prog,
+    size_t* prog_len,
+    const char* hrp,
+    const char* addr
+);
+
+/** Encode a Bech32 string
+ *
+ *  Out: output:  Pointer to a buffer of size strlen(hrp) + data_len + 8 that
+ *                will be updated to contain the null-terminated Bech32 string.
+ *  In: hrp :     Pointer to the null-terminated human readable part.
+ *      data :    Pointer to an array of 5-bit values.
+ *      data_len: Length of the data array.
+ *  Returns 1 if successful.
+ */
+int bech32_encode(
+    char *output,
+    const char *hrp,
+    const uint8_t *data,
+    size_t data_len
+);
+
+/** Decode a Bech32 string
+ *
+ *  Out: hrp:      Pointer to a buffer of size strlen(input) - 6. Will be
+ *                 updated to contain the null-terminated human readable part.
+ *       data:     Pointer to a buffer of size strlen(input) - 8 that will
+ *                 hold the encoded 5-bit data values.
+ *       data_len: Pointer to a size_t that will be updated to be the number
+ *                 of entries in data.
+ *  In: input:     Pointer to a null-terminated Bech32 string.
+ *  Returns 1 if succesful.
+ */
+int bech32_decode(
+    char *hrp,
+    uint8_t *data,
+    size_t *data_len,
+    const char *input
+);
+
+#endif

--- a/tests.sh
+++ b/tests.sh
@@ -147,6 +147,41 @@ OUTPUT=$($BITCOIN_TOOL \
         --output-format base58check \
         --input "${INPUT}")
 check "${TEST}" "${OUTPUT}" "${EXPECTED}" || exit 1
+# -----------------------------------------------------------------------------
+TEST="13 - convert WIF private key to address bech32"
+EXPECTED="bc1qhmc0vk4xzr37ayv7tlyhns7x4dk04tyvflk8ey"
+INPUT="L3GzRAGwCqfSNFr6g1NQm7edn29DgAKZJ6owUBqYELpP6Kbim5kM"
+OUTPUT=$($BITCOIN_TOOL \
+        --input-type private-key-wif \
+        --output-type address \
+        --input-format base58check \
+        --network bitcoin \
+        --output-format bech32 \
+        --input "${INPUT}")
+check "${TEST}" "${OUTPUT}" "${EXPECTED}" || exit 1
+# -----------------------------------------------------------------------------
+TEST="14 - bech32 address, to hex ripemd160 hash of public key"
+EXPECTED="bef0f65aa610e3ee919e5fc979c3c6ab6cfaac8c"
+INPUT="bc1qhmc0vk4xzr37ayv7tlyhns7x4dk04tyvflk8ey"
+OUTPUT=$($BITCOIN_TOOL \
+	--input-type address \
+	--input-format bech32 \
+	--input "${INPUT}" \
+	--output-type public-key-rmd \
+	--output-format hex )
+check "${TEST}" "${OUTPUT}" "${EXPECTED}" || exit 1
+# -----------------------------------------------------------------------------
+TEST="15 - convert WIF private key to ripemd160 hash of public key"
+EXPECTED="bef0f65aa610e3ee919e5fc979c3c6ab6cfaac8c"
+INPUT="L3GzRAGwCqfSNFr6g1NQm7edn29DgAKZJ6owUBqYELpP6Kbim5kM"
+OUTPUT=$($BITCOIN_TOOL \
+        --input-type private-key-wif \
+        --output-type public-key-rmd \
+        --input-format base58check \
+        --network bitcoin \
+        --output-format hex \
+        --input "${INPUT}")
+check "${TEST}" "${OUTPUT}" "${EXPECTED}" || exit 1
 
 # -----------------------------------------------------------------------------
 # Test various different network prefixes


### PR DESCRIPTION
this adds an input/output format 'bech32' which enables the generation of p2wpkh addresses like bc1qhmc0vk4xzr37ayv7tlyhns7x4dk04tyvflk8ey.  3 new tests have been added:

- "13 - convert WIF private key to address bech32"
- "14 - bech32 address, to hex ripemd160 hash of public key"
- "15 - convert WIF private key to ripemd160 hash of public key"
 
example usage: 
./bitcoin-tool --network bitcoin --input L3GzRAGwCqfSNFr6g1NQm7edn29DgAKZJ6owUBqYELpP6Kbim5kM --input-type private-key-wif --input-format base58check --output-type address --output-format bech32
